### PR TITLE
fix: umount issue leaves global lock

### DIFF
--- a/internal/syncmap/syncmap.go
+++ b/internal/syncmap/syncmap.go
@@ -1,0 +1,73 @@
+package syncmap
+
+import (
+	"encoding/json"
+	"sync"
+)
+
+func New[A any]() *SyncMap[A] {
+	return &SyncMap[A]{data: make(map[string]A)}
+}
+
+type SyncMap[A any] struct {
+	data map[string]A
+	lock sync.RWMutex
+}
+
+func (s *SyncMap[A]) Put(key string, value A) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.data[key] = value
+}
+
+func (s *SyncMap[A]) Get(key string) (A, bool) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	val, ok := s.data[key]
+	return val, ok
+}
+
+func (s *SyncMap[A]) Delete(key string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	delete(s.data, key)
+}
+
+func (s *SyncMap[A]) MarshalJSON() ([]byte, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	return json.Marshal(s.data)
+}
+
+func (s *SyncMap[A]) UnmarshalJSON(data []byte) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return json.Unmarshal(data, &s.data)
+}
+
+func (s *SyncMap[A]) Keys() []string {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	result := make([]string, 0, len(s.data))
+	for key := range s.data {
+		result = append(result, key)
+	}
+	return result
+}
+
+func (s *SyncMap[A]) Values() []A {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	result := make([]A, 0, len(s.data))
+	for _, value := range s.data {
+		result = append(result, value)
+	}
+	return result
+}

--- a/internal/syncmap/syncmap_suite_test.go
+++ b/internal/syncmap/syncmap_suite_test.go
@@ -1,0 +1,13 @@
+package syncmap_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSyncmap(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Syncmap Suite")
+}

--- a/internal/syncmap/syncmap_test.go
+++ b/internal/syncmap/syncmap_test.go
@@ -1,0 +1,94 @@
+package syncmap_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"code.cloudfoundry.org/volumedriver/internal/syncmap"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SyncMap", func() {
+	It("can put and get concurrently", func() {
+		s := syncmap.New[int]()
+
+		const workers = 100
+		var wg sync.WaitGroup
+		wg.Add(workers)
+		for i := 0; i < workers; i++ {
+			go func(workerID int) {
+				defer GinkgoRecover()
+				defer wg.Done()
+
+				key := fmt.Sprintf("%d", workerID)
+				s.Put(key, workerID)
+				time.Sleep(100 * time.Millisecond)
+				value, _ := s.Get(key)
+				Expect(value).To(Equal(workerID))
+			}(i)
+		}
+
+		wg.Wait()
+	})
+
+	It("can report whether a value exists", func() {
+		s := syncmap.New[int]()
+		s.Put("exists", 42)
+
+		v1, ok1 := s.Get("exists")
+		Expect(v1).To(Equal(42))
+		Expect(ok1).To(BeTrue())
+
+		v2, ok2 := s.Get("doesn't exist")
+		Expect(v2).To(Equal(0))
+		Expect(ok2).To(BeFalse())
+	})
+
+	It("can delete a value", func() {
+		const key = "exists"
+		s := syncmap.New[int]()
+		s.Put(key, 42)
+		_, ok1 := s.Get(key)
+		Expect(ok1).To(BeTrue())
+
+		s.Delete(key)
+		_, ok2 := s.Get(key)
+		Expect(ok2).To(BeFalse())
+	})
+
+	It("can be marshalled into JSON", func() {
+		s := syncmap.New[any]()
+		s.Put("foo", "bar")
+		s.Put("baz", 42)
+		Expect(json.Marshal(s)).To(MatchJSON(`{"foo":"bar","baz":42}`))
+	})
+
+	It("can be unmarshalled from JSON", func() {
+		const input = `{"foo":"bar","baz":42}`
+		s := syncmap.New[any]()
+
+		Expect(json.Unmarshal([]byte(input), s)).To(Succeed())
+		Expect(json.Marshal(s)).To(MatchJSON(input))
+	})
+
+	It("can return a list of keys", func() {
+		s := syncmap.New[any]()
+		s.Put("foo", "bar")
+		s.Put("baz", 42)
+		s.Put("quz", false)
+
+		Expect(s.Keys()).To(ConsistOf("foo", "baz", "quz"))
+	})
+
+	It("can return a list of values", func() {
+		s := syncmap.New[string]()
+		s.Put("foo", "bar")
+		s.Put("baz", "quz")
+		s.Put("duz", "fuz")
+
+		Expect(s.Values()).To(ConsistOf("bar", "fuz", "quz"))
+	})
+})


### PR DESCRIPTION
We saw an issue where one Unmount operation suspended, and because it had the `volumeLock` locked, subsequent operations also all suspended because they could not obtain the lock.

We have refactored locking access to the `volumes` map so that fewer operations happen under lock, and a deadlock is now less likely.