### PR TITLE
decrement mount count if unmount fails

### DIFF
--- a/volume_driver.go
+++ b/volume_driver.go
@@ -21,24 +21,30 @@ import (
 
 // MountPointNotExistError indicates that the mount point does not exist.
 // This error is created to handle the case when the mount point does not exist during an unmount operation.
+// It wraps the original os.ErrNotExist error.
 type MountPointNotExistError struct {
 	VolumeName string
 	MountPath  string
+	err        error
 }
 
 func (e *MountPointNotExistError) Error() string {
-	return fmt.Sprintf("Volume %s does not exist (path: %s)", e.VolumeName, e.MountPath)
+	return fmt.Sprintf("Volume %s does not exist (path: %s): %v", e.VolumeName, e.MountPath, e.err)
+}
+
+func (e *MountPointNotExistError) Unwrap() error {
+	return e.err
 }
 
 // removeMountPath attempts to remove the mount path directory.
-// If os.ErrNotExist is returned, it returns MountPointNotExistError to allow mount count decrement.
+// If os.ErrNotExist is returned, it returns MountPointNotExistError wrapping the original error to allow mount count decrement.
 func (d *VolumeDriver) removeMountPath(logger lager.Logger, name, mountPath string, context string) error {
 	err := d.os.Remove(mountPath)
 	if err != nil {
-		// If os.Remove returns os.ErrNotExist, return a special error that allows mount count decrement
+		// If os.Remove returns os.ErrNotExist, wrap it in a special error that allows mount count decrement
 		if errors.Is(err, os.ErrNotExist) {
 			logger.Info("mountpoint-not-exist", lager.Data{"volume": name, "mountpath": mountPath, "context": context})
-			return &MountPointNotExistError{VolumeName: name, MountPath: mountPath}
+			return &MountPointNotExistError{VolumeName: name, MountPath: mountPath, err: err}
 		}
 		return err
 	}
@@ -233,6 +239,25 @@ func (d *VolumeDriver) Path(env dockerdriver.Env, pathRequest dockerdriver.PathR
 	return dockerdriver.PathResponse{Mountpoint: vol.Mountpoint}
 }
 
+// decrementMountCount decrements the mount count for a volume and updates or removes it from the state.
+// If the mount count reaches 0, the volume is removed from the volumes map.
+func (d *VolumeDriver) decrementMountCount(logger lager.Logger, volumeName string) {
+	volume, ok := d.volumes.Get(volumeName)
+	if !ok {
+		return
+	}
+
+	volume.MountCount--
+	logger.Info("volume-ref-count-decremented", lager.Data{"name": volume.Name, "count": volume.MountCount})
+
+	switch volume.MountCount {
+	case 0:
+		d.volumes.Delete(volumeName)
+	default:
+		d.volumes.Put(volumeName, volume)
+	}
+}
+
 func (d *VolumeDriver) Unmount(env dockerdriver.Env, unmountRequest dockerdriver.UnmountRequest) dockerdriver.ErrorResponse {
 	logger := env.Logger().Session("unmount", lager.Data{"volume": unmountRequest.Name})
 	logger.Info("start")
@@ -255,31 +280,26 @@ func (d *VolumeDriver) Unmount(env dockerdriver.Env, unmountRequest dockerdriver
 		return dockerdriver.ErrorResponse{Err: errText}
 	}
 
+	var unmountErr error
 	if volume.MountCount == 1 {
-		if err := d.unmount(driverhttp.EnvWithLogger(logger, env), unmountRequest.Name, volume.Mountpoint); err != nil {
-			// If the mount point doesn't exist, decrement the mount count
-			var mountPointNotExistErr *MountPointNotExistError
-			if errors.As(err, &mountPointNotExistErr) {
-				logger.Info("mountpoint-not-exist-continue-decrement", lager.Data{"volume": unmountRequest.Name, "mountpath": volume.Mountpoint})
-				// Continue with mount count decrement below
-			} else {
-				return dockerdriver.ErrorResponse{Err: err.Error()}
-			}
-		}
+		unmountErr = d.unmount(driverhttp.EnvWithLogger(logger, env), unmountRequest.Name, volume.Mountpoint)
 	}
 
-	volume.MountCount--
-	logger.Info("volume-ref-count-decremented", lager.Data{"name": volume.Name, "count": volume.MountCount})
+	// Always decrement the mount count, even if unmount failed
+	d.decrementMountCount(logger, unmountRequest.Name)
 
-	switch volume.MountCount {
-	case 0:
-		d.volumes.Delete(unmountRequest.Name)
-	default:
-		d.volumes.Put(unmountRequest.Name, volume)
-	}
-
+	// Persist state after decrementing (even if unmount failed)
 	if err := d.persistState(driverhttp.EnvWithLogger(logger, env)); err != nil {
 		return dockerdriver.ErrorResponse{Err: fmt.Sprintf("failed to persist state when unmounting: %s", err.Error())}
+	}
+
+	// If unmount failed, return error after decrementing and persisting
+	if unmountErr != nil {
+		var mountPointNotExistErr *MountPointNotExistError
+		if errors.As(unmountErr, &mountPointNotExistErr) {
+			logger.Info("mountpoint-not-exist-return-error", lager.Data{"volume": unmountRequest.Name, "mountpath": volume.Mountpoint})
+		}
+		return dockerdriver.ErrorResponse{Err: unmountErr.Error()}
 	}
 
 	return dockerdriver.ErrorResponse{}
@@ -465,7 +485,7 @@ func (d *VolumeDriver) unmount(env dockerdriver.Env, name string, mountPath stri
 			}
 			errText := fmt.Sprintf("Volume %s does not exist (path: %s) and unable to remove mount directory", name, mountPath)
 			logger.Info("mountpoint-not-found", lager.Data{"msg": errText})
-			return errors.New(errText)
+			return fmt.Errorf("%s: %w", errText, err)
 		}
 
 		errText := fmt.Sprintf("Volume %s does not exist (path: %s)", name, mountPath)
@@ -478,7 +498,7 @@ func (d *VolumeDriver) unmount(env dockerdriver.Env, name string, mountPath stri
 	err = d.mounter.Unmount(env, mountPath)
 	if err != nil {
 		logger.Error("unmount-failed", err)
-		return fmt.Errorf("error unmounting volume: %s", err.Error())
+		return fmt.Errorf("error unmounting volume: %w", err)
 	}
 
 	err = d.removeMountPath(logger, name, mountPath, "after-unmount")
@@ -488,7 +508,7 @@ func (d *VolumeDriver) unmount(env dockerdriver.Env, name string, mountPath stri
 			return err
 		}
 		logger.Error("remove-mountpoint-failed", err)
-		return fmt.Errorf("error removing mountpoint: %s", err.Error())
+		return fmt.Errorf("error removing mountpoint: %w", err)
 	}
 
 	logger.Info("unmounted-volume")

--- a/volume_driver_test.go
+++ b/volume_driver_test.go
@@ -348,9 +348,12 @@ var _ = Describe("Nfs Driver", func() {
 							Expect(strings.Replace(unmountResponse.Err, `\`, "/", -1)).To(Equal("Volume " + volumeName + " does not exist (path: /path/to/mount/" + volumeName + ")"))
 						})
 
-						It("/VolumeDriver.Get still returns the mountpoint", func() {
-							getResponse := ExpectVolumeExists(env, volumeDriver, volumeName)
-							Expect(getResponse.Volume.Mountpoint).NotTo(Equal(""))
+						It("decrements the mount count and removes the volume from state", func() {
+							// When mount count is 1 and mountpath is not found, volume is removed after decrement
+							getResponse := volumeDriver.Get(env, dockerdriver.GetRequest{
+								Name: volumeName,
+							})
+							Expect(getResponse.Err).To(Equal("volume not found"))
 						})
 					})
 
@@ -401,7 +404,8 @@ var _ = Describe("Nfs Driver", func() {
 							})
 
 							It("still decrements the mount count and removes the volume from state", func() {
-								Expect(unmountResponse.Err).To(Equal(""))
+								// Unmount returns an error but still decrements mount count
+								Expect(unmountResponse.Err).To(ContainSubstring("Volume " + volumeName + " does not exist"))
 								Expect(fakeOs.RemoveCallCount()).To(Equal(1))
 
 								// Verify the volume is removed from state (mount count reached 0)
@@ -425,7 +429,8 @@ var _ = Describe("Nfs Driver", func() {
 						})
 
 						It("still decrements the mount count and removes the volume from state", func() {
-							Expect(unmountResponse.Err).To(Equal(""))
+							// Unmount returns an error but still decrements mount count
+							Expect(unmountResponse.Err).To(ContainSubstring("Volume " + volumeName + " does not exist"))
 							Expect(fakeMounter.UnmountCallCount()).To(Equal(1))
 							Expect(fakeOs.RemoveCallCount()).To(Equal(1))
 

--- a/volume_driver_test.go
+++ b/volume_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -392,6 +393,47 @@ var _ = Describe("Nfs Driver", func() {
 							It("returns an error", func() {
 								Expect(unmountResponse.Err).To(ContainSubstring("Volume test-volume-id does not exist (path: /path/to/mount/test-volume-id) and unable to remove mount directory"))
 							})
+						})
+
+						Context("when os.Remove returns os.ErrNotExist", func() {
+							BeforeEach(func() {
+								fakeOs.RemoveReturns(os.ErrNotExist)
+							})
+
+							It("still decrements the mount count and removes the volume from state", func() {
+								Expect(unmountResponse.Err).To(Equal(""))
+								Expect(fakeOs.RemoveCallCount()).To(Equal(1))
+
+								// Verify the volume is removed from state (mount count reached 0)
+								getResponse := volumeDriver.Get(env, dockerdriver.GetRequest{
+									Name: volumeName,
+								})
+								Expect(getResponse.Err).To(Equal("volume not found"))
+							})
+
+							It("writes the driver state to disk", func() {
+								// 3 - unmount (when os.Remove returns os.ErrNotExist)
+								Expect(fakeOs.WriteFileCallCount()).To(Equal(3))
+							})
+						})
+					})
+
+					Context("when unmount succeeds but os.Remove returns os.ErrNotExist", func() {
+						BeforeEach(func() {
+							fakeMounter.UnmountReturns(nil)
+							fakeOs.RemoveReturns(os.ErrNotExist)
+						})
+
+						It("still decrements the mount count and removes the volume from state", func() {
+							Expect(unmountResponse.Err).To(Equal(""))
+							Expect(fakeMounter.UnmountCallCount()).To(Equal(1))
+							Expect(fakeOs.RemoveCallCount()).To(Equal(1))
+
+							// Verify the volume is removed from state (mount count reached 0)
+							getResponse := volumeDriver.Get(env, dockerdriver.GetRequest{
+								Name: volumeName,
+							})
+							Expect(getResponse.Err).To(Equal("volume not found"))
 						})
 					})
 				})


### PR DESCRIPTION
Summary
----------
This PR addresses the issue describe in https://vmw-jira.broadcom.net/browse/TNZ-71700. Following changes are made:

(1) One new custom error type `MountPointNotExistError` for wrapping os.ErrNotExist() error.
(2) Two new private methods `removeMountPath()` and `decrementMountCount` on VolumeDriver. This removes code duplication in many places.
(3) Will any of the callers fail because of error wrapping? No. 
(4) New unit tests are added.

```
Summary of Error code Paths
-------------------------------------------------------------------------------------------------------
Error Path                              Mount Count decremented ?      Error Preserved ?
                                        BEFORE  |   AFTER              BEFORE    |    AFTER
-------------------------------------------------------------------------------------------------------
Validation errors                        No     |   No                 n/a       |    n/a
mountChecker.Exists()                    No     |   Yes                Yes       |    Yes
os.Remove() -> os.ErrNotExist            No     |   Yes                Yes       |    Yes  (wrapped)
os.Remove() -> other errors              No     |   Yes                Yes       |    Yes  (wrapped)
Mount not exist, remove succeeds         No     |   Yes                n/a       |    n/a
mounter.Unmount()                        No     |   Yes                No        |    Yes  (wrapped)
persistState()                           No     |   Yes                No        |    No
--------------------------------------------------------------------------------------------------------
```

Backward Compatibility
------------------------
Yes, backward compatible.
